### PR TITLE
upgrade: Minecraft 1.21.3 + Architectury API 14.0.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,16 @@ All versions live in `gradle.properties`. When targeting a new Minecraft version
 5. Update `neoforge_api_version` and `neoforge_version_range` (NeoForge major/minor tracks MC, e.g. `[21.3,)` for MC `1.21.3`).
 6. Fetch `https://raw.githubusercontent.com/architectury/architectury-api/{lowest_game_version}/build.gradle` and copy the `dev.architectury.loom` version into `build.gradle`.
 
+### Known source changes by MC version
+
+When upgrading, code in `common/` may need fixes for MC API changes. The NeoForge migration primers are the primary reference — check the one matching the version you're upgrading to:
+
+```
+https://github.com/neoforged/.github/blob/main/primers/{mc_version}/index.md
+```
+
+For method-level renames not covered by the primer, extract the class from the Minecraft jar in the Loom cache and run `strings` on it to list all method names.
+
 ## Commits
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/).

--- a/common/src/main/java/me/edoren/skin_changer/client/ImageUtils.java
+++ b/common/src/main/java/me/edoren/skin_changer/client/ImageUtils.java
@@ -19,7 +19,7 @@ public class ImageUtils {
                 return PlayerSkin.Model.WIDE; // it's actually "legacy", but there will always be a filter to convert them into "default".
             if (w == h) {
                 int r = Math.max(w / 64, 1);
-                if (((image.getPixelRGBA(55 * r, 20 * r) & 0xFF000000) >>> 24) == 0)
+                if (((image.getPixel(55 * r, 20 * r) & 0xFF000000) >>> 24) == 0)
                     return PlayerSkin.Model.SLIM;
                 return PlayerSkin.Model.WIDE;
             }
@@ -77,18 +77,18 @@ public class ImageUtils {
     private static void setAreaOpaque(NativeImage image, int x, int y, int width, int height) {
         for (int i = x; i < width; i++)
             for (int j = y; j < height; j++)
-                image.setPixelRGBA(i, j, image.getPixelRGBA(i, j) | 0xFF000000);
+                image.setPixel(i, j, image.getPixel(i, j) | 0xFF000000);
     }
 
     private static void setAreaTransparent(NativeImage image, int x, int y, int width, int height) {
         for (int i = x; i < width; i++)
             for (int j = y; j < height; j++)
-                if ((image.getPixelRGBA(i, j) >> 24 & 0xFF) < 128)
+                if ((image.getPixel(i, j) >> 24 & 0xFF) < 128)
                     return;
 
         for (int l = x; l < width; l++)
             for (int i1 = y; i1 < height; i1++)
-                image.setPixelRGBA(l, i1, image.getPixelRGBA(l, i1) & 0xFFFFFF);
+                image.setPixel(l, i1, image.getPixel(l, i1) & 0xFFFFFF);
     }
 
     public static boolean isNotValidData(byte[] data) {

--- a/common/src/main/java/me/edoren/skin_changer/server/SkinsCommand.java
+++ b/common/src/main/java/me/edoren/skin_changer/server/SkinsCommand.java
@@ -5,7 +5,6 @@ import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import me.edoren.skin_changer.common.SharedPool;
-import net.minecraft.commands.CommandSource;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.EntityArgument;
@@ -85,99 +84,89 @@ public class SkinsCommand {
     }
 
     private static Integer setPlayerSkin(CommandSourceStack source, Entity targetEntity, String arg) {
-        CommandSource sourcePlayer = source.getServer();
-        if (source.getEntity() != null) {
-            sourcePlayer = source.getEntity();
-        }
         Player targetPlayer = (Player) targetEntity;
         try {
             URL url = new URL(arg);
-            return setPlayerSkinByURL(sourcePlayer, targetPlayer, url);
+            return setPlayerSkinByURL(source, targetPlayer, url);
         } catch (MalformedURLException e) {
-            return setPlayerSkinByName(sourcePlayer, targetPlayer, arg);
+            return setPlayerSkinByName(source, targetPlayer, arg);
         }
     }
 
-    private static Integer setPlayerSkinByName(CommandSource sourcePlayer, Player targetPlayer, String playerName) {
-        sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.loading")));
+    private static Integer setPlayerSkinByName(CommandSourceStack source, Player targetPlayer, String playerName) {
+        source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.loading")));
         SharedPool.get().execute(() -> {
             if (!SkinProviderController.GetInstance().setPlayerSkinByName(targetPlayer.getGameProfile(), playerName, true)) {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.load_failed")));
+                source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.load_failed")));
             } else {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.load_succeeded")));
+                source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.load_succeeded")));
             }
         });
         return 1;
     }
 
-    private static Integer setPlayerSkinByURL(CommandSource sourcePlayer, Player targetPlayer, URL url) {
-        sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.loading")));
+    private static Integer setPlayerSkinByURL(CommandSourceStack source, Player targetPlayer, URL url) {
+        source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.loading")));
         SharedPool.get().execute(() -> {
             if (!SkinProviderController.GetInstance().setPlayerSkinByURL(targetPlayer.getGameProfile(), url, true)) {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.load_failed")));
+                source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.load_failed")));
             } else {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.load_succeeded")));
+                source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.load_succeeded")));
             }
         });
         return 1;
     }
 
     private static Integer setPlayerCape(CommandSourceStack source, Entity targetEntity, String arg) {
-        CommandSource sourcePlayer = source.getServer();
-        if (source.getEntity() != null) {
-            sourcePlayer = source.getEntity();
-        }
         Player targetPlayer = (Player) targetEntity;
         try {
             URL url = new URL(arg);
-            return setPlayerCapeByURL(sourcePlayer, targetPlayer, url);
+            return setPlayerCapeByURL(source, targetPlayer, url);
         } catch (MalformedURLException e) {
-            return setPlayerCapeByName(sourcePlayer, targetPlayer, arg);
+            return setPlayerCapeByName(source, targetPlayer, arg);
         }
     }
 
-    private static Integer setPlayerCapeByName(CommandSource sourcePlayer, Player targetPlayer, String playerName) {
-        sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.loading")));
+    private static Integer setPlayerCapeByName(CommandSourceStack source, Player targetPlayer, String playerName) {
+        source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.loading")));
         SharedPool.get().execute(() -> {
             if (!SkinProviderController.GetInstance().setPlayerCapeByName(targetPlayer.getGameProfile(), playerName, true)) {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.load_failed")));
+                source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.load_failed")));
             } else {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.load_succeeded")));
+                source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.load_succeeded")));
             }
         });
         return 1;
     }
 
-    private static Integer setPlayerCapeByURL(CommandSource sourcePlayer, Player targetPlayer, URL url) {
-        sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.loading")));
+    private static Integer setPlayerCapeByURL(CommandSourceStack source, Player targetPlayer, URL url) {
+        source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.loading")));
         SharedPool.get().execute(() -> {
             if (!SkinProviderController.GetInstance().setPlayerCapeByURL(targetPlayer.getGameProfile(), url, true)) {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.load_failed")));
+                source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.load_failed")));
             } else {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.load_succeeded")));
+                source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.load_succeeded")));
             }
         });
         return 1;
     }
 
-    private static Integer clearPlayerSkin(CommandSourceStack source, Entity targetEntity) throws CommandSyntaxException {
-        Player sourcePlayer = (Player) source.getEntityOrException();
+    private static Integer clearPlayerSkin(CommandSourceStack source, Entity targetEntity) {
         Player targetPlayer = (Player) targetEntity;
-        sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.removing")));
+        source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.removing")));
         SharedPool.get().execute(() -> {
             SkinProviderController.GetInstance().clearPlayerSkin(targetPlayer.getGameProfile());
-            sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.remove_succeeded")));
+            source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.remove_succeeded")));
         });
         return 1;
     }
 
-    private static Integer clearPlayerCape(CommandSourceStack source, Entity targetEntity) throws CommandSyntaxException {
-        Player sourcePlayer = (Player) source.getEntityOrException();
+    private static Integer clearPlayerCape(CommandSourceStack source, Entity targetEntity) {
         Player targetPlayer = (Player) targetEntity;
-        sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.removing")));
+        source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.removing")));
         SharedPool.get().execute(() -> {
             SkinProviderController.GetInstance().clearPlayerCape(targetPlayer.getGameProfile());
-            sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.remove_succeeded")));
+            source.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.remove_succeeded")));
         });
         return 1;
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,17 +7,17 @@ org.gradle.parallel=true
 ## Environment Properties
 java_version = 21
 
-minecraft_version = 1.21.1
-minecraft_version_range = [1.21,1.21.1]
+minecraft_version = 1.21.3
+minecraft_version_range = [1.21.2,1.21.3]
 
-architectury_api_version = 13.0.8
-architectury_version_range = [13.0.8,)
+architectury_api_version = 14.0.4
+architectury_version_range = [14.0.4,)
 
 fabric_loader_version = 0.19.3
-fabric_api_version = 0.116.12+1.21.1
+fabric_api_version = 0.114.1+1.21.3
 
-neoforge_api_version = 21.1.234
-neoforge_version_range = [21.1,)
+neoforge_api_version = 21.3.96
+neoforge_version_range = [21.3,)
 neoforge_loader_version_range = [2,)
 
 ## Mod Properties


### PR DESCRIPTION
## Summary

- Bumps `minecraft_version` to `1.21.3` and `architectury_api_version` to `14.0.4`
- Updates `fabric_api_version` to `0.114.1+1.21.3` and `neoforge_api_version` to `21.3.96`
- Fixes `NativeImage` pixel API rename (`getPixelRGBA`/`setPixelRGBA` → `getPixel`/`setPixel`)
- Fixes command feedback routing — `Entity` no longer implements `CommandSource` in 1.21.2+, so `sendSystemMessage` now goes through `CommandSourceStack` directly
- Documents MC API migration resources in `CLAUDE.md`

## Manual testing

- [ ] Load the mod on a 1.21.3 Fabric server and verify skin/cape commands work in-game
- [ ] Load the mod on a 1.21.3 NeoForge server and verify skin/cape commands work in-game

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated compatibility for Minecraft 1.21.3 and related platform APIs.
* **Bug Fixes**
  * Improved skin image handling to more accurately determine slim/wide layout and preserve alpha transparency during legacy filtering.
* **Bug Fixes**
  * Skin and cape commands now use consistent command context and provide clearer loading/removal progress with success/failure feedback while running updates asynchronously.
* **Documentation**
  * Added migration guidance for reviewing known source changes by MC version, including an additional method-level rename workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->