### PR TITLE
fix(common): replace crafatar.com with working mirror fallback chain

### DIFF
--- a/common/src/main/java/me/edoren/skin_changer/server/providers/CrafatarCapeProvider.java
+++ b/common/src/main/java/me/edoren/skin_changer/server/providers/CrafatarCapeProvider.java
@@ -3,10 +3,20 @@ package me.edoren.skin_changer.server.providers;
 import me.edoren.skin_changer.common.NetworkUtils;
 
 public class CrafatarCapeProvider implements ISkinProvider {
+    private static final String[] MIRRORS = {
+        "https://skins.manacube.com/capes/%s",
+        "https://crafatar.imthespyke.fr/capes/%s",
+        "https://crafatar-pub.neodium.fr/capes/%s"
+    };
+
     @Override
     public byte[] getSkin(String playerName) {
         String uuid = NetworkUtils.getPlayerUUID(playerName);
         if (uuid == null) return null;
-        return NetworkUtils.downloadFile(String.format("https://crafatar.com/capes/%s", uuid), null, 2);
+        for (String mirror : MIRRORS) {
+            byte[] data = NetworkUtils.downloadFile(String.format(mirror, uuid), null, 1);
+            if (data != null) return data;
+        }
+        return null;
     }
 }

--- a/common/src/main/java/me/edoren/skin_changer/server/providers/CrafatarSkinProvider.java
+++ b/common/src/main/java/me/edoren/skin_changer/server/providers/CrafatarSkinProvider.java
@@ -3,10 +3,20 @@ package me.edoren.skin_changer.server.providers;
 import me.edoren.skin_changer.common.NetworkUtils;
 
 public class CrafatarSkinProvider implements ISkinProvider {
+    private static final String[] MIRRORS = {
+        "https://skins.manacube.com/skins/%s",
+        "https://crafatar.imthespyke.fr/skins/%s",
+        "https://crafatar-pub.neodium.fr/skins/%s"
+    };
+
     @Override
     public byte[] getSkin(String playerName) {
         String uuid = NetworkUtils.getPlayerUUID(playerName);
         if (uuid == null) return null;
-        return NetworkUtils.downloadFile(String.format("https://crafatar.com/skins/%s", uuid), null, 2);
+        for (String mirror : MIRRORS) {
+            byte[] data = NetworkUtils.downloadFile(String.format(mirror, uuid), null, 1);
+            if (data != null) return data;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Fixes #72

## Summary

`crafatar.com` is down. Both `CrafatarSkinProvider` and `CrafatarCapeProvider` now try three known public Crafatar mirrors in order, falling back to the next if one fails:

1. `skins.manacube.com`
2. `crafatar.imthespyke.fr`
3. `crafatar-pub.neodium.fr`

Retries per mirror reduced from 2 to 1 so a dead host fails fast and the next mirror is reached sooner. The existing `MineskinSkinProvider` still acts as a final fallback for skins.

## Manual testing

- [ ] Run `/skin set <playerName>` and verify the skin loads correctly
- [ ] Run `/cape set <playerName>` and verify the cape loads correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skin and cape loading reliability by trying multiple download sources instead of relying on a single endpoint.
  * If one source is unavailable, the app now automatically falls back to another, reducing failed cosmetic fetches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->