### PR TITLE
fix(common): reduce log verbosity from INFO to DEBUG/WARN

### DIFF
--- a/common/src/main/java/me/edoren/skin_changer/client/api/SkinLoaderService.java
+++ b/common/src/main/java/me/edoren/skin_changer/client/api/SkinLoaderService.java
@@ -34,10 +34,10 @@ public class SkinLoaderService {
             return;
         }
 
-        LogManager.getLogger().info("Loading skin for player {}", model);
+        LogManager.getLogger().debug("Loading skin for player {}", model);
 
         if (ImageUtils.isNotValidData(data)) {
-            LogManager.getLogger().info("Error loading skin for player {}", model);
+            LogManager.getLogger().warn("Error loading skin for player {}", model);
             return;
         }
 
@@ -59,10 +59,10 @@ public class SkinLoaderService {
             return;
         }
 
-        LogManager.getLogger().info("Loading cape for player {}", model);
+        LogManager.getLogger().debug("Loading cape for player {}", model);
 
         if (ImageUtils.isNotValidData(data)) {
-            LogManager.getLogger().info("Error loading cape for player {}", model);
+            LogManager.getLogger().warn("Error loading cape for player {}", model);
             return;
         }
 
@@ -74,7 +74,7 @@ public class SkinLoaderService {
     public void requestPlayerSkin(PlayerModel model) {
         if (loadedSkins.containsKey(model) || playerSkinRequests.containsKey(model)) return;
 
-        LogManager.getLogger().info("Requesting skin for player {}", model);
+        LogManager.getLogger().debug("Requesting skin for player {}", model);
 
         Object signal = new Object();
         playerSkinRequests.put(model, signal);
@@ -85,7 +85,7 @@ public class SkinLoaderService {
                 try {
                     signal.wait(5000);
                 } catch (InterruptedException e) {
-                    LogManager.getLogger().info("Error requesting skin for player {}", model);
+                    LogManager.getLogger().warn("Error requesting skin for player {}", model);
                 }
                 playerSkinRequests.remove(model);
             }

--- a/common/src/main/java/me/edoren/skin_changer/common/NetworkUtils.java
+++ b/common/src/main/java/me/edoren/skin_changer/common/NetworkUtils.java
@@ -60,14 +60,14 @@ public class NetworkUtils {
                     stream.write(dataBuffer, 0, bytesRead);
                 }
 
-                LogManager.getLogger().info("File {} downloaded", url);
+                LogManager.getLogger().debug("File {} downloaded", url);
                 return stream.toByteArray();
             } catch (FileNotFoundException ignored) {
                 return null;
             } catch (IOException ignored) {
             }
         }
-        LogManager.getLogger().info("Error downloading file {}", url);
+        LogManager.getLogger().warn("Error downloading file {}", url);
         return null;
     }
 

--- a/common/src/main/java/me/edoren/skin_changer/server/ServerMessageHandler.java
+++ b/common/src/main/java/me/edoren/skin_changer/server/ServerMessageHandler.java
@@ -49,7 +49,7 @@ public class ServerMessageHandler {
     static void processMessage(PlayerSkinRequestMessage message, ServerPlayer sendingPlayer) {
         SharedPool.execute(() -> {
             GameProfile profile = message.getPlayer().toGameProfile();
-            LogManager.getLogger().info("Requested skin for player {}[{}]", profile.getName(), profile.getId());
+            LogManager.getLogger().debug("Requested skin for player {}[{}]", profile.getName(), profile.getId());
             if (!SkinProviderController.GetInstance().getPlayerSkin(profile, sendingPlayer)) {
                 SkinProviderController.GetInstance().setPlayerSkinByName(profile, message.getPlayer().getName(), false);
             }

--- a/common/src/main/java/me/edoren/skin_changer/server/SkinProviderController.java
+++ b/common/src/main/java/me/edoren/skin_changer/server/SkinProviderController.java
@@ -142,7 +142,7 @@ public class SkinProviderController {
         if (cache)
             savePlayerDataToCache(dataType, model, data);
         sendPlayerDataToAll(model);
-        LogManager.getLogger().info("Loaded {} for player {}", dataType, model);
+        LogManager.getLogger().debug("Loaded {} for player {}", dataType, model);
         return true;
     }
 
@@ -205,7 +205,7 @@ public class SkinProviderController {
 
                 Path filePath = Paths.get(cacheFolders.get(dataType), fileUUID);
                 Files.write(filePath, bytes);
-                LogManager.getLogger().info("Caching file {}", filePath.toString());
+                LogManager.getLogger().debug("Caching file {}", filePath.toString());
             } catch (IOException e) {
                 LogManager.getLogger().warn("Exception while calling savePlayerDataToCache", e);
             }
@@ -221,7 +221,7 @@ public class SkinProviderController {
                     if (file.isFile()) {
                         byte[] data = Files.readAllBytes(file.toPath());
                         loadedData.get(dataType).put(playerModel, data);
-                        LogManager.getLogger().info("Loading local {} for player {}", dataType, playerModel);
+                        LogManager.getLogger().debug("Loading local {} for player {}", dataType, playerModel);
                         return true;
                     }
                     break;
@@ -246,7 +246,7 @@ public class SkinProviderController {
                         File fileToRemove = dataType.equals(DataType.SKIN) ? dataFileSkin : dataFileCape;
 
                         if (fileToRemove.isFile() && fileToRemove.delete()) {
-                            LogManager.getLogger().info("Removing {} for player {}", dataType, model);
+                            LogManager.getLogger().debug("Removing {} for player {}", dataType, model);
                         }
 
                         if (!dataFileSkin.isFile() && !dataFileSkin.isFile()) {
@@ -279,7 +279,7 @@ public class SkinProviderController {
 
     private void onPlayerLogin(ServerPlayer player) {
         GameProfile profile = player.getGameProfile();
-        LogManager.getLogger().info("Player {} just logged in with id {}", profile.getName(), profile.getId());
+        LogManager.getLogger().debug("Player {} just logged in with id {}", profile.getName(), profile.getId());
         SharedPool.get().execute(() -> {
             sendAllDataToTarget(player);
             PlayerModel model = new PlayerModel(profile);
@@ -301,7 +301,7 @@ public class SkinProviderController {
         GameProfile profile = player.getGameProfile();
         PlayerModel model = new PlayerModel(profile);
         if (loadedData.get(DataType.SKIN).containsKey(model) || loadedData.get(DataType.CAPE).containsKey(model)) {
-            LogManager.getLogger().info("Removing session data for player {}[{}]", profile.getName(), profile.getId());
+            LogManager.getLogger().debug("Removing session data for player {}[{}]", profile.getName(), profile.getId());
             loadedData.get(DataType.SKIN).remove(model);
             loadedData.get(DataType.CAPE).remove(model);
             sendPlayerDataToAll(model);


### PR DESCRIPTION
## Summary

- Operational messages (skin requests, cache hits, login/logout, successful downloads) changed from `INFO` to `DEBUG` — they no longer appear in the server log by default
- Failed download and invalid data messages changed from `INFO` to `WARN` — real errors still surface
- Fixes #61 (server log spam)

## Re-enabling verbose output

Server admins who want the detailed logs back can add a `log4j2.xml` to their server root:

```xml
<Logger name="me.edoren.skin_changer" level="debug" additivity="false">
    <AppenderRef ref="ServerGuiConsole"/>
    <AppenderRef ref="File"/>
    <AppenderRef ref="TerminalConsole"/>
</Logger>
```

## Manual test

Start a server and verify the `latest.log` no longer fills with skin-request or download messages during normal play. Warnings still appear when a mirror is unreachable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced log verbosity across skin loading, network downloads, message handling, and session/cache operations.
  * Shifted routine success messages to debug level and surfaced failures with clearer warning-level logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->