### PR TITLE
feat(common): add config file with chat message toggle

### DIFF
--- a/common/src/main/java/me/edoren/skin_changer/common/SkinChangerConfig.java
+++ b/common/src/main/java/me/edoren/skin_changer/common/SkinChangerConfig.java
@@ -26,7 +26,8 @@ public class SkinChangerConfig {
 
         if (Files.exists(file)) {
             try (Reader r = Files.newBufferedReader(file)) {
-                instance = gson.fromJson(r, SkinChangerConfig.class);
+                SkinChangerConfig parsed = gson.fromJson(r, SkinChangerConfig.class);
+                instance = parsed != null ? parsed : new SkinChangerConfig();
             } catch (IOException e) {
                 LogManager.getLogger().warn("Failed to read {}, using defaults", file, e);
                 instance = new SkinChangerConfig();

--- a/common/src/main/java/me/edoren/skin_changer/common/SkinChangerConfig.java
+++ b/common/src/main/java/me/edoren/skin_changer/common/SkinChangerConfig.java
@@ -1,0 +1,44 @@
+package me.edoren.skin_changer.common;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.logging.log4j.LogManager;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class SkinChangerConfig {
+    public boolean showChatMessages = true;
+
+    private static SkinChangerConfig instance;
+
+    public static SkinChangerConfig get() {
+        if (instance == null) instance = new SkinChangerConfig();
+        return instance;
+    }
+
+    public static void load(Path configDir) {
+        Path file = configDir.resolve(Constants.MOD_ID + ".json");
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+        if (Files.exists(file)) {
+            try (Reader r = Files.newBufferedReader(file)) {
+                instance = gson.fromJson(r, SkinChangerConfig.class);
+            } catch (IOException e) {
+                LogManager.getLogger().warn("Failed to read {}, using defaults", file, e);
+                instance = new SkinChangerConfig();
+            }
+        } else {
+            instance = new SkinChangerConfig();
+        }
+
+        try (Writer w = Files.newBufferedWriter(file)) {
+            gson.toJson(instance, w);
+        } catch (IOException e) {
+            LogManager.getLogger().warn("Failed to write {}", file, e);
+        }
+    }
+}

--- a/common/src/main/java/me/edoren/skin_changer/server/ServerController.java
+++ b/common/src/main/java/me/edoren/skin_changer/server/ServerController.java
@@ -1,13 +1,17 @@
 package me.edoren.skin_changer.server;
 
 import me.edoren.skin_changer.common.Constants;
+import me.edoren.skin_changer.common.SkinChangerConfig;
 import me.edoren.skin_changer.server.providers.CrafatarCapeProvider;
 import me.edoren.skin_changer.server.providers.CrafatarSkinProvider;
 import me.edoren.skin_changer.server.providers.MineskinSkinProvider;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.level.storage.LevelResource;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -25,6 +29,14 @@ public class ServerController {
     }
 
     public void initialize(MinecraftServer server) {
+        Path configDir = server.getServerDirectory().resolve("config");
+        try {
+            Files.createDirectories(configDir);
+        } catch (IOException e) {
+            LogManager.getLogger().warn("Failed to create config directory", e);
+        }
+        SkinChangerConfig.load(configDir);
+
         Path savesFolder = server.getWorldPath(LevelResource.ROOT);
         File skinChangerFolder = Paths.get(savesFolder.toString(), Constants.MOD_ID).normalize().toFile();
 

--- a/common/src/main/java/me/edoren/skin_changer/server/SkinsCommand.java
+++ b/common/src/main/java/me/edoren/skin_changer/server/SkinsCommand.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import me.edoren.skin_changer.common.SharedPool;
+import me.edoren.skin_changer.common.SkinChangerConfig;
 import net.minecraft.commands.CommandSource;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -20,6 +21,12 @@ import java.net.URL;
 @SuppressWarnings("SameReturnValue")
 public class SkinsCommand {
     static final Component ISSUER = Component.literal("SkinChanger");
+
+    private static void sendMessage(CommandSource player, Component msg) {
+        if (SkinChangerConfig.get().showChatMessages) {
+            player.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, msg));
+        }
+    }
 
     public static ArgumentBuilder<CommandSourceStack, ?> setCommand(Function3<CommandSourceStack, Player, String, Integer> setFunction,
                                                                     Function<CommandContext<CommandSourceStack>, Player> getTarget) {
@@ -99,24 +106,24 @@ public class SkinsCommand {
     }
 
     private static Integer setPlayerSkinByName(CommandSource sourcePlayer, Player targetPlayer, String playerName) {
-        sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.loading")));
+        sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.skin.loading"));
         SharedPool.get().execute(() -> {
             if (!SkinProviderController.GetInstance().setPlayerSkinByName(targetPlayer.getGameProfile(), playerName, true)) {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.load_failed")));
+                sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.skin.load_failed"));
             } else {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.load_succeeded")));
+                sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.skin.load_succeeded"));
             }
         });
         return 1;
     }
 
     private static Integer setPlayerSkinByURL(CommandSource sourcePlayer, Player targetPlayer, URL url) {
-        sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.loading")));
+        sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.skin.loading"));
         SharedPool.get().execute(() -> {
             if (!SkinProviderController.GetInstance().setPlayerSkinByURL(targetPlayer.getGameProfile(), url, true)) {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.load_failed")));
+                sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.skin.load_failed"));
             } else {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.load_succeeded")));
+                sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.skin.load_succeeded"));
             }
         });
         return 1;
@@ -137,24 +144,24 @@ public class SkinsCommand {
     }
 
     private static Integer setPlayerCapeByName(CommandSource sourcePlayer, Player targetPlayer, String playerName) {
-        sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.loading")));
+        sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.cape.loading"));
         SharedPool.get().execute(() -> {
             if (!SkinProviderController.GetInstance().setPlayerCapeByName(targetPlayer.getGameProfile(), playerName, true)) {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.load_failed")));
+                sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.cape.load_failed"));
             } else {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.load_succeeded")));
+                sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.cape.load_succeeded"));
             }
         });
         return 1;
     }
 
     private static Integer setPlayerCapeByURL(CommandSource sourcePlayer, Player targetPlayer, URL url) {
-        sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.loading")));
+        sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.cape.loading"));
         SharedPool.get().execute(() -> {
             if (!SkinProviderController.GetInstance().setPlayerCapeByURL(targetPlayer.getGameProfile(), url, true)) {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.load_failed")));
+                sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.cape.load_failed"));
             } else {
-                sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.load_succeeded")));
+                sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.cape.load_succeeded"));
             }
         });
         return 1;
@@ -163,10 +170,10 @@ public class SkinsCommand {
     private static Integer clearPlayerSkin(CommandSourceStack source, Entity targetEntity) throws CommandSyntaxException {
         Player sourcePlayer = (Player) source.getEntityOrException();
         Player targetPlayer = (Player) targetEntity;
-        sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.removing")));
+        sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.skin.removing"));
         SharedPool.get().execute(() -> {
             SkinProviderController.GetInstance().clearPlayerSkin(targetPlayer.getGameProfile());
-            sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.skin.remove_succeeded")));
+            sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.skin.remove_succeeded"));
         });
         return 1;
     }
@@ -174,10 +181,10 @@ public class SkinsCommand {
     private static Integer clearPlayerCape(CommandSourceStack source, Entity targetEntity) throws CommandSyntaxException {
         Player sourcePlayer = (Player) source.getEntityOrException();
         Player targetPlayer = (Player) targetEntity;
-        sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.removing")));
+        sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.cape.removing"));
         SharedPool.get().execute(() -> {
             SkinProviderController.GetInstance().clearPlayerCape(targetPlayer.getGameProfile());
-            sourcePlayer.sendSystemMessage(Component.translatable("chat.type.announcement", ISSUER, Component.translatable("commands.skin_changer.cape.remove_succeeded")));
+            sendMessage(sourcePlayer, Component.translatable("commands.skin_changer.cape.remove_succeeded"));
         });
         return 1;
     }


### PR DESCRIPTION
## Summary

- Adds `config/skinchanger.json`, created automatically on first server start with defaults
- New option `showChatMessages` (default: `true`) — set to `false` to suppress the `[SkinChanger] Loading…` / success / fail messages sent to players when they run `/skin` or `/cape` commands
- Centralises all chat feedback through a `sendMessage()` helper in `SkinsCommand`, reducing duplication
- Closes #52

## Config file location

`<server-root>/config/skin_changer.json`

```json
{
  "showChatMessages": true
}
```

## Manual test

1. Start a server — verify `config/skin_changer.json` is created with `showChatMessages: true`
2. Run `/skin set <name>` — chat feedback appears as usual
3. Stop server, set `"showChatMessages": false`, restart
4. Run `/skin set <name>` — no chat feedback, skin still changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to show or hide chat messages for skin and cape actions.
  * The server now creates a config directory and loads saved settings automatically on startup.

* **Bug Fixes**
  * Chat announcements for loading, success, failure, and removal actions now respect the new notification setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->