### PR TITLE
ci: post PR comment with artifact download links

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -6,15 +6,75 @@ on:
   pull_request:
     branches: [ "master" ]
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
 
     steps:
+    - name: Post or update pending comment
+      id: post-comment
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const marker = '<!-- skinchanger-ci-artifacts -->';
+          const statusStart = '<!-- sc-status-start -->';
+          const statusEnd = '<!-- sc-status-end -->';
+          const sha = context.payload.pull_request.head.sha.slice(0, 7);
+
+          const comments = await github.paginate(github.rest.issues.listComments, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          });
+          const existing = comments.find(c => c.body && c.body.includes(marker));
+
+          const statusBlock = `${statusStart}\n⏳ **Build \`${sha}\` in progress…**\n${statusEnd}`;
+
+          let body;
+          let commentId;
+          if (existing) {
+            // Strip any previous status block, keep the last result
+            const escStart = statusStart.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const escEnd = statusEnd.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const resultPart = existing.body
+              .replace(marker, '')
+              .replace(new RegExp(`\\n*${escStart}[\\s\\S]*?${escEnd}\\n*`), '')
+              .trim();
+            body = resultPart
+              ? `${marker}\n\n${statusBlock}\n\n${resultPart}`
+              : `${marker}\n\n${statusBlock}`;
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+            commentId = existing.id;
+          } else {
+            body = `${marker}\n\n${statusBlock}`;
+            const { data: comment } = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+            commentId = comment.id;
+          }
+          core.setOutput('comment-id', String(commentId));
+
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
@@ -25,4 +85,56 @@ jobs:
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
     - name: Build with Gradle Wrapper
+      id: build
       run: ./gradlew build
+
+    - name: Upload Fabric artifact
+      id: upload-fabric
+      if: steps.build.outcome == 'success'
+      uses: actions/upload-artifact@v4
+      with:
+        name: fabric
+        path: fabric/build/libs/*.jar
+        if-no-files-found: error
+
+    - name: Upload NeoForge artifact
+      id: upload-neoforge
+      if: steps.build.outcome == 'success'
+      uses: actions/upload-artifact@v4
+      with:
+        name: neoforge
+        path: neoforge/build/libs/*.jar
+        if-no-files-found: error
+
+    - name: Update comment with results
+      if: always() && github.event_name == 'pull_request' && steps.post-comment.outputs.comment-id != ''
+      uses: actions/github-script@v7
+      env:
+        FABRIC_URL: ${{ steps.upload-fabric.outputs.artifact-url }}
+        NEOFORGE_URL: ${{ steps.upload-neoforge.outputs.artifact-url }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        COMMENT_ID: ${{ steps.post-comment.outputs.comment-id }}
+      with:
+        script: |
+          const marker = '<!-- skinchanger-ci-artifacts -->';
+          const fabricUrl = process.env.FABRIC_URL;
+          const neoforgeUrl = process.env.NEOFORGE_URL;
+          const runUrl = process.env.RUN_URL;
+          const sha = context.payload.pull_request.head.sha.slice(0, 7);
+
+          const body = (fabricUrl && neoforgeUrl)
+            ? [
+                marker,
+                `✅ **Build \`${sha}\` succeeded!** Download the artifacts below:`,
+                '',
+                `- [Fabric](${fabricUrl})`,
+                `- [NeoForge](${neoforgeUrl})`,
+              ].join('\n')
+            : `${marker}\n❌ **Build \`${sha}\` failed.** See the [workflow run](${runUrl}) for details.`;
+
+          await github.rest.issues.updateComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: Number(process.env.COMMENT_ID),
+            body,
+          });


### PR DESCRIPTION
## Summary

- Extends the existing CI workflow to post a single comment on each PR when the build starts, then updates it in place with artifact download links (or a failure link) once the build finishes
- Uses an HTML marker to find and update the existing comment rather than creating a new one on every push
- No effect on direct pushes to master — comment steps are gated by `github.event_name == 'pull_request'`

## Test plan

- [ ] Open a new PR and verify `github-actions[bot]` posts a "build in progress" comment immediately
- [ ] Wait for the build to finish and verify the comment is updated with Fabric and NeoForge artifact links
- [ ] Push another commit to the same PR and verify the comment is updated in place (not a new comment)
- [ ] Introduce a build failure and verify the comment is updated with a link to the failed run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated pull request status comment that transitions from “build in progress” to final results.
  * On success, the comment now includes direct download links for both Fabric and NeoForge artifacts.
* **Bug Fixes**
  * Improved reliability of status updates by reusing a single marked comment and updating it with clear success/failure output.
* **Chores**
  * Enhanced CI efficiency by canceling older in-progress runs for the same pull request when new commits are pushed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->