### PR TITLE
feat: add configurable max skin file size limit

### DIFF
--- a/common/src/main/java/me/edoren/skin_changer/common/NetworkUtils.java
+++ b/common/src/main/java/me/edoren/skin_changer/common/NetworkUtils.java
@@ -31,9 +31,13 @@ public class NetworkUtils {
     }
 
     public static byte[] downloadFile(String resource, Proxy proxy, int maxRetries) {
+        return downloadFile(resource, proxy, maxRetries, 0);
+    }
+
+    public static byte[] downloadFile(String resource, Proxy proxy, int maxRetries, long maxBytes) {
         try {
             URL url = new URL(resource);
-            return downloadFile(url, proxy, maxRetries);
+            return downloadFile(url, proxy, maxRetries, maxBytes);
         } catch (MalformedURLException e) {
             LogManager.getLogger().error("Exception while calling downloadFile", e);
             return null;
@@ -41,6 +45,10 @@ public class NetworkUtils {
     }
 
     public static byte[] downloadFile(URL url, Proxy proxy, int maxRetries) {
+        return downloadFile(url, proxy, maxRetries, 0);
+    }
+
+    public static byte[] downloadFile(URL url, Proxy proxy, int maxRetries, long maxBytes) {
         LogManager.getLogger().debug("Downloading file {}", url);
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         for (int i = 0; i < maxRetries; i++) {
@@ -52,12 +60,24 @@ public class NetworkUtils {
                 urlConnection.setRequestMethod("GET");
                 urlConnection.connect();
 
+                if (maxBytes > 0) {
+                    long contentLength = urlConnection.getContentLengthLong();
+                    if (contentLength > maxBytes) {
+                        LogManager.getLogger().warn("Skipping {} — Content-Length {} exceeds limit of {} bytes", url, contentLength, maxBytes);
+                        return null;
+                    }
+                }
+
                 BufferedInputStream in = new BufferedInputStream(urlConnection.getInputStream());
 
                 byte[] dataBuffer = new byte[1024];
                 int bytesRead;
                 while ((bytesRead = in.read(dataBuffer, 0, 1024)) != -1) {
                     stream.write(dataBuffer, 0, bytesRead);
+                    if (maxBytes > 0 && stream.size() > maxBytes) {
+                        LogManager.getLogger().warn("Skipping {} — size exceeds limit of {} bytes", url, maxBytes);
+                        return null;
+                    }
                 }
 
                 LogManager.getLogger().info("File {} downloaded", url);

--- a/common/src/main/java/me/edoren/skin_changer/common/SkinChangerConfig.java
+++ b/common/src/main/java/me/edoren/skin_changer/common/SkinChangerConfig.java
@@ -12,6 +12,11 @@ import java.nio.file.Path;
 
 public class SkinChangerConfig {
     public boolean showChatMessages = true;
+    public int maxSkinFileSizeKb = 512;
+
+    public long maxSkinFileSizeBytes() {
+        return maxSkinFileSizeKb * 1024L;
+    }
 
     private static SkinChangerConfig instance;
 

--- a/common/src/main/java/me/edoren/skin_changer/server/SkinProviderController.java
+++ b/common/src/main/java/me/edoren/skin_changer/server/SkinProviderController.java
@@ -8,6 +8,7 @@ import dev.architectury.utils.GameInstance;
 import me.edoren.skin_changer.common.NetworkContext;
 import me.edoren.skin_changer.common.NetworkUtils;
 import me.edoren.skin_changer.common.SharedPool;
+import me.edoren.skin_changer.common.SkinChangerConfig;
 import me.edoren.skin_changer.common.messages.PlayerSkinUpdateMessage;
 import me.edoren.skin_changer.common.models.PlayerModel;
 import me.edoren.skin_changer.common.models.PlayerSkinModel;
@@ -116,7 +117,7 @@ public class SkinProviderController {
     }
 
     private boolean setPlayerDataByURL(PlayerModel model, URL url, boolean cache, DataType dataType) {
-        byte[] data = NetworkUtils.downloadFile(url.toString(), null, 2);
+        byte[] data = NetworkUtils.downloadFile(url, null, 2, SkinChangerConfig.get().maxSkinFileSizeBytes());
         return storePlayerData(model, data, cache, dataType);
     }
 

--- a/common/src/main/java/me/edoren/skin_changer/server/providers/CrafatarCapeProvider.java
+++ b/common/src/main/java/me/edoren/skin_changer/server/providers/CrafatarCapeProvider.java
@@ -1,6 +1,7 @@
 package me.edoren.skin_changer.server.providers;
 
 import me.edoren.skin_changer.common.NetworkUtils;
+import me.edoren.skin_changer.common.SkinChangerConfig;
 
 public class CrafatarCapeProvider implements ISkinProvider {
     private static final String[] MIRRORS = {
@@ -14,7 +15,7 @@ public class CrafatarCapeProvider implements ISkinProvider {
         String uuid = NetworkUtils.getPlayerUUID(playerName);
         if (uuid == null) return null;
         for (String mirror : MIRRORS) {
-            byte[] data = NetworkUtils.downloadFile(String.format(mirror, uuid), null, 1);
+            byte[] data = NetworkUtils.downloadFile(String.format(mirror, uuid), null, 1, SkinChangerConfig.get().maxSkinFileSizeBytes());
             if (data != null) return data;
         }
         return null;

--- a/common/src/main/java/me/edoren/skin_changer/server/providers/CrafatarSkinProvider.java
+++ b/common/src/main/java/me/edoren/skin_changer/server/providers/CrafatarSkinProvider.java
@@ -1,6 +1,7 @@
 package me.edoren.skin_changer.server.providers;
 
 import me.edoren.skin_changer.common.NetworkUtils;
+import me.edoren.skin_changer.common.SkinChangerConfig;
 
 public class CrafatarSkinProvider implements ISkinProvider {
     private static final String[] MIRRORS = {
@@ -14,7 +15,7 @@ public class CrafatarSkinProvider implements ISkinProvider {
         String uuid = NetworkUtils.getPlayerUUID(playerName);
         if (uuid == null) return null;
         for (String mirror : MIRRORS) {
-            byte[] data = NetworkUtils.downloadFile(String.format(mirror, uuid), null, 1);
+            byte[] data = NetworkUtils.downloadFile(String.format(mirror, uuid), null, 1, SkinChangerConfig.get().maxSkinFileSizeBytes());
             if (data != null) return data;
         }
         return null;

--- a/common/src/main/java/me/edoren/skin_changer/server/providers/MineskinSkinProvider.java
+++ b/common/src/main/java/me/edoren/skin_changer/server/providers/MineskinSkinProvider.java
@@ -1,12 +1,13 @@
 package me.edoren.skin_changer.server.providers;
 
 import me.edoren.skin_changer.common.NetworkUtils;
+import me.edoren.skin_changer.common.SkinChangerConfig;
 
 public class MineskinSkinProvider implements ISkinProvider {
     @Override
     public byte[] getSkin(String playerName) {
         String uuid = NetworkUtils.getPlayerUUID(playerName);
         if (uuid == null) return null;
-        return NetworkUtils.downloadFile(String.format("https://mineskin.eu/skin/%s", uuid), null, 2);
+        return NetworkUtils.downloadFile(String.format("https://mineskin.eu/skin/%s", uuid), null, 2, SkinChangerConfig.get().maxSkinFileSizeBytes());
     }
 }


### PR DESCRIPTION
Closes #54

## Summary

- Adds `maxSkinFileSizeKb` field to `SkinChangerConfig` (default: 512 KB, written to `config/skin_changer.json` on first run)
- Adds `maxSkinFileSizeBytes()` convenience method to avoid repeating the `* 1024L` conversion at call sites
- Extends `NetworkUtils.downloadFile` with a `long maxBytes` parameter (0 = unlimited, preserving existing behaviour)
  - Checks `Content-Length` header before starting to read — bails early if it exceeds the limit
  - Tracks cumulative bytes during the streaming loop — returns `null` and logs `WARN` if exceeded mid-transfer
- All skin/cape download call sites (`CrafatarSkinProvider`, `CrafatarCapeProvider`, `MineskinSkinProvider`, `SkinProviderController`) now pass the configured limit

## Test plan

- [ ] Build succeeds on Fabric and NeoForge
- [ ] Start server — confirm `config/skin_changer.json` is created with `"maxSkinFileSizeKb": 512`
- [ ] `/skin set <url to image > 512 KB>` — server log shows WARN, skin does not change
- [ ] `/skin set <url to normal skin>` — succeeds as before
- [ ] Set `maxSkinFileSizeKb: 1` in config, restart, set any skin — blocked